### PR TITLE
feat: Add instruction about envsubst for Mac Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ composer create-project lch/docker-wordpress target-dir 1.1.6
 
 This will clone the stack in your directory
 
+### Requirements
+
+**Mac users** : During installation, the script requires the use of envsubst which is not installed by default on MacOS. You can install it directly with Homebrew:
+
+```
+brew install gettext
+brew link --force gettext 
+```
+
 ## Configuration
 ### Custom parameters
 


### PR DESCRIPTION
In order to initialise the project correctly on MacOS, we add instruction about dependency envsubst for mac users in readme file.