### PR TITLE
Upgrade whole theme installation to Sage 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ sage: install
 	docker-compose exec --user www-data php bash -c "cd ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME} && composer install"
 
 	# Activate sage theme
-	docker-compose exec --user www-data php wp theme activate ${PROJECT_NAME}
+	docker-compose exec --user www-data php wp theme activate ${PROJECT_NAME}/resources
 
 	# Remove standard themes
 	docker-compose exec --user www-data php wp theme delete twentysixteen twentyseventeen twentynineteen

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ sage: install
 	docker-compose exec --user www-data php wp theme activate ${PROJECT_NAME}/resources
 
 	# Remove standard themes
-	docker-compose exec --user www-data php wp theme delete twentysixteen twentyseventeen twentynineteen
+	docker-compose exec --user www-data php wp theme delete twentysixteen twentyseventeen twentynineteen twentytwenty
 
 # Build app
 install: build composer-install

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ bash-php-root: up
 
 sage: install
 	# Install Roots Sage
-	docker-compose exec --user www-data php composer create-project roots/sage ${PROJECT_NAME} 8.5.3
+	docker-compose exec --user www-data php composer create-project roots/sage ${PROJECT_NAME} 9.0.9
 
 	# First compilation
 	# cd ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME}
@@ -21,9 +21,13 @@ sage: install
 	docker-compose exec --user www-data php mv ${PROJECT_NAME} wp-content/themes
 
 	# Install nodes modules
-	docker-compose exec --user www-data php npm install --prefix ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME}
+	docker-compose exec --user www-data php yarn install --prefix ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME}
 
-	docker-compose exec --user www-data php bash -c "cd ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME} && bower install && gulp --production"
+
+	docker-compose exec --user www-data php bash -c "cd ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME} && yarn run build"
+
+	# Build sage theme composer
+	docker-compose exec --user www-data php bash -c "cd ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME} && composer install"
 
 	# Activate sage theme
 	docker-compose exec --user www-data php wp theme activate ${PROJECT_NAME}
@@ -67,8 +71,8 @@ install: build composer-install
 	docker-compose exec --user www-data php wp rewrite flush --hard
 
 
-gulp: up
-	docker-compose exec --user www-data php bash -c "cd ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME} && bower install && gulp --production"
+build-assets: up
+	docker-compose exec --user www-data php bash -c "cd ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME} && yarn install && yarn build:production"
 
 composer-install: up
 	# Install PHP dependencies

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ sage: install
 	docker-compose exec --user www-data php mv ${PROJECT_NAME} wp-content/themes
 
 	# Install nodes modules
-	docker-compose exec --user www-data php yarn install --prefix ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME}
+	docker-compose exec --user www-data php yarn install --cwd ${WORDPRESS_HOST_RELATIVE_APP_PATH}wp-content/themes/${PROJECT_NAME}
 
 
 	docker-compose exec --user www-data php bash -c "cd ${WORDPRESS_HOST_RELATIVE_APP_PATH}/wp-content/themes/${PROJECT_NAME} && yarn run build"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ First of all, specify parameters needed for the project
 - __MYSQL_DATABASE_PREFIX__: THe database prefix you want for your Wordpress installation
 - __MYSQL_USER__: THe database user you want to use (will be created on container creation)
 - __MYSQL_PASSWORD__: the database password you want 
-- __MYSQL_HOST_PORT: the host port you want to bind Mysql Server in container to. 
+- __MYSQL_HOST_PORT__: the host port you want to bind Mysql Server in container to. 
 - __MYSQL_PORT__: the MySQL instance port. Careful, this is the MySQL port __in container__. Default to `3306`  
 - __MYSQL_HOST_VOLUME_PATH__: default `./docker/data/mysql/5.7`. This is the volume which will store database.
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ There are 2 ways to use this : __initialisation__ and __day-to-day usage__. A `M
 #### Blank project
 Just execute `make install` to completly setup blank project. Please look to other entry points in `Makefile` to see what you can do
 
-#### Project with Sage 8.5.3 theme
+#### Project with Sage 9 theme
 
-Just execute `make sage` to set a complete project with Sage 8.5.3. Sage 9 is coming...
+Just execute `make sage` to set a complete project with Sage 9.
 
 ### Day-to-day usage
 

--- a/docker/images/php-fpm7.2/Dockerfile
+++ b/docker/images/php-fpm7.2/Dockerfile
@@ -47,12 +47,6 @@ RUN mv wp-cli.phar /usr/local/bin/wp
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
 RUN apt-get install -y nodejs
 
-# Install Bower globally
-RUN npm install -g bower
-
-# Install Gulp globally
-RUN npm install -g gulp
-
 # Yarn install
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
Complete change of the theme installation procedure to use Webpack instead of Gulp & Bower.

I changed the command of the Makefile (gulp) to rename it to "build-assets". It was just a useful function for developers and was not used in compilation scripts.

I find it better because suddenly it's a little friendlier name.

I thought in a next PR to add the deployment of assets. I don't know what you think?